### PR TITLE
[EREEFS-403] Drupal module calendar is 1 month offset

### DIFF
--- a/js/EAtlasNcAnimate2Widget.js
+++ b/js/EAtlasNcAnimate2Widget.js
@@ -970,7 +970,8 @@ EAtlasNcAnimate2Widget.prototype.parseDate = function(dateStr) {
         return null;
     }
 
-    var date = moment(dateStr);
+    // Parse date without applying timezone offset
+    var date = moment.parseZone(dateStr);
     if (date.isValid()) {
         return date;
     }


### PR DESCRIPTION
- Changed moment(dateStr) to moment.parseZone(dateStr) to avoid timezone conversion while parsing the date (i.e. the date parsing is not related to user browser's timezone).